### PR TITLE
character_class をリファクタリング

### DIFF
--- a/include/rime.hpp
+++ b/include/rime.hpp
@@ -545,32 +545,33 @@ namespace rime {
 
 
     fn class_ranges(I& it, const S fin) {
-      // NonemptyClassRanges
-      if (class_atom(it, fin) == class_atom_result::rbracket) {
-        // 空の場合
-        return;
-      }
-
-      if (it == fin) {
-        // []が閉じていない
-        REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
-      }
-      if (*it == chars::hyphen) {
-        consume(it);
-        if (it == fin) {
-          // []が閉じていない
-          REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
-        }
+      for (;;) {
+        // NonemptyClassRanges
         if (class_atom(it, fin) == class_atom_result::rbracket) {
-          // 続くClassRangesは空
+          // 空の場合
           return;
         }
+
         if (it == fin) {
           // []が閉じていない
           REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
         }
+        if (*it == chars::hyphen) {
+          consume(it);
+          if (it == fin) {
+            // []が閉じていない
+            REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
+          }
+          if (class_atom(it, fin) == class_atom_result::rbracket) {
+            // 続くClassRangesは空
+            return;
+          }
+          if (it == fin) {
+            // []が閉じていない
+            REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
+          }
+        }
       }
-      class_ranges(it, fin);
     }
 
     fn class_atom(I& it, const S fin) -> class_atom_result {

--- a/include/rime.hpp
+++ b/include/rime.hpp
@@ -547,10 +547,6 @@ namespace rime {
     fn class_ranges(I& it, const S fin) {
       for (;;) {
         // NonemptyClassRanges
-        if (it == fin) {
-          // []が閉じていない
-          REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
-        }
         if (class_atom(it, fin) == class_atom_result::rbracket) {
           // 空の場合
           return;
@@ -562,10 +558,6 @@ namespace rime {
         }
         if (*it == chars::hyphen) {
           consume(it);
-          if (it == fin) {
-            // []が閉じていない
-            REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
-          }
           if (class_atom(it, fin) == class_atom_result::rbracket) {
             // 続くClassRangesは空
             return;
@@ -575,6 +567,11 @@ namespace rime {
     }
 
     fn class_atom(I& it, const S fin) -> class_atom_result {
+      if (it == fin) {
+        // []が閉じていない
+        REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
+      }
+
       const auto c = *it;
 
       if (c == chars::hyphen) {

--- a/include/rime.hpp
+++ b/include/rime.hpp
@@ -512,12 +512,7 @@ namespace rime {
 
     fn character_class(I& it, const S fin) {
       consume(it);
-      if (it == fin) {
-        // []が閉じていない
-        REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
-      }
-      
-      if (*it == chars::caret) {
+      if (it != fin and *it == chars::caret) {
         consume(it);
       }
 
@@ -548,11 +543,7 @@ namespace rime {
           return;
         }
 
-        if (it == fin) {
-          // []が閉じていない
-          REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
-        }
-        if (*it == chars::hyphen) {
+        if (it != fin and *it == chars::hyphen) {
           consume(it);
           if (class_atom(it, fin) == class_atom_result::rbracket) {
             // 続くClassRangesは空

--- a/include/rime.hpp
+++ b/include/rime.hpp
@@ -578,7 +578,9 @@ namespace rime {
 
     fn nonempty_class_ranges_nodash(I& it, const S fin) {
 
-      if (class_atom(it, fin) != class_atom_result::class_atom_nodash) {
+      // 呼び出される前に chars::hyphen じゃない事をチェックしているので
+      // ここでは class_atom_result::hyphen は返ってこない
+      if (class_atom(it, fin) == class_atom_result::rbracket) {
         // - or POSIXクラス、あるいは]を読んで帰ってきた時
         return;
       }

--- a/include/rime.hpp
+++ b/include/rime.hpp
@@ -554,24 +554,13 @@ namespace rime {
 
       const auto c = *it;
 
-      if (c == chars::hyphen) {
-        consume(it);
-        return class_atom_result::hyphen;
-      }
-
-      return class_atom_nodash(it, fin);
-    }
-
-    fn class_atom_nodash(I& it, const S fin) -> class_atom_result {
-      const auto c = *it;
-
       switch (c) {
       case chars::backslash:
         class_escape(it, fin);
         return class_atom_result::class_atom_nodash;
       case chars::hyphen:
-        REGEX_PATTERN_ERROR("Unreachable");
-        break;
+        consume(it);
+        return class_atom_result::hyphen;
       case chars::rbracket:
         return class_atom_result::rbracket;
       case chars::lbracket:

--- a/include/rime.hpp
+++ b/include/rime.hpp
@@ -517,14 +517,7 @@ namespace rime {
       }
 
       class_ranges(it, fin);
-
-      if (*it == chars::rbracket) {
-        consume(it);
-        return;
-      } else {
-        // []が閉じていない
-        REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
-      }
+      consume(it);
     }
 
     // class_atomがどの構文をパースして帰っているのかを伝える

--- a/include/rime.hpp
+++ b/include/rime.hpp
@@ -521,7 +521,7 @@ namespace rime {
     }
 
     // class_atomがどの構文をパースして帰っているのかを伝える
-    enum class class_atom_result : unsigned char { 
+    enum class class_atom_result : bool {
       other,
       rbracket
     };

--- a/include/rime.hpp
+++ b/include/rime.hpp
@@ -572,44 +572,10 @@ namespace rime {
         class_ranges(it, fin);
         return;
       } else {
-        nonempty_class_ranges_nodash(it, fin);
-      }
-    }
-
-    fn nonempty_class_ranges_nodash(I& it, const S fin) {
-
-      // 呼び出される前に chars::hyphen じゃない事をチェックしているので
-      // ここでは class_atom_result::hyphen は返ってこない
-      if (class_atom(it, fin) == class_atom_result::rbracket) {
-        // - or POSIXクラス、あるいは]を読んで帰ってきた時
-        return;
-      }
-      // ClassAtomNoDashを読んだ時
-
-      if (it == fin) {
-        // []が閉じていない
-        REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
-      }
-      if (*it == chars::hyphen) {
-        consume(it);
-        if (it == fin) {
-          // []が閉じていない
-          REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
-        }
-        if (class_atom(it, fin) == class_atom_result::rbracket) {
-          // 続くClassRangesは空
-          return;
-        }
-        if (it == fin) {
-          // []が閉じていない
-          REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
-        }
         class_ranges(it, fin);
-      } else {
-        nonempty_class_ranges_nodash(it, fin);
       }
     }
-  
+
     fn class_atom(I& it, const S fin) -> class_atom_result {
       const auto c = *it;
 

--- a/include/rime.hpp
+++ b/include/rime.hpp
@@ -519,10 +519,6 @@ namespace rime {
       
       if (*it == chars::caret) {
         consume(it);
-        if (it == fin) {
-          // []が閉じていない
-          REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
-        }
       }
 
       class_ranges(it, fin);

--- a/include/rime.hpp
+++ b/include/rime.hpp
@@ -522,8 +522,7 @@ namespace rime {
 
     // class_atomがどの構文をパースして帰っているのかを伝える
     enum class class_atom_result : unsigned char { 
-      hyphen,
-      class_atom_nodash,
+      other,
       rbracket
     };
 
@@ -557,20 +556,17 @@ namespace rime {
       switch (c) {
       case chars::backslash:
         class_escape(it, fin);
-        return class_atom_result::class_atom_nodash;
-      case chars::hyphen:
-        consume(it);
-        return class_atom_result::hyphen;
+        return class_atom_result::other;
       case chars::rbracket:
         return class_atom_result::rbracket;
       case chars::lbracket:
         if (posix_class(it, fin) == true) {
-          return class_atom_result::class_atom_nodash;
+          return class_atom_result::other;
         }
         [[fallthrough]];
       default:
         consume(it);
-        return class_atom_result::class_atom_nodash;
+        return class_atom_result::other;
       }
     }
 

--- a/include/rime.hpp
+++ b/include/rime.hpp
@@ -547,6 +547,10 @@ namespace rime {
     fn class_ranges(I& it, const S fin) {
       for (;;) {
         // NonemptyClassRanges
+        if (it == fin) {
+          // []が閉じていない
+          REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
+        }
         if (class_atom(it, fin) == class_atom_result::rbracket) {
           // 空の場合
           return;
@@ -565,10 +569,6 @@ namespace rime {
           if (class_atom(it, fin) == class_atom_result::rbracket) {
             // 続くClassRangesは空
             return;
-          }
-          if (it == fin) {
-            // []が閉じていない
-            REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
           }
         }
       }

--- a/include/rime.hpp
+++ b/include/rime.hpp
@@ -569,11 +569,8 @@ namespace rime {
           // []が閉じていない
           REGEX_PATTERN_ERROR("The range of character(character class) is not closed.");
         }
-        class_ranges(it, fin);
-        return;
-      } else {
-        class_ranges(it, fin);
       }
+      class_ranges(it, fin);
     }
 
     fn class_atom(I& it, const S fin) -> class_atom_result {


### PR DESCRIPTION
`class_ranges` と `nonempty_class_ranges_nodash` の相互再帰がちょっと気になったので、`character_class`  とその配下（？）をリファクタリングしてみました。
挙動は変わっていないハズです。（テストは通った）

ちょっとずつリファクタリングしていったんですが、結果として文法規則の原形をとどめない物になってしまったので、乖離が激しいとメンテナンスしづらい等あれば、気にせずリジェクトしてください！